### PR TITLE
Updated Calendar to display learning units visually

### DIFF
--- a/iOS Dev Calendar/Extensions/Day/DayView.ColoredCircle.swift
+++ b/iOS Dev Calendar/Extensions/Day/DayView.ColoredCircle.swift
@@ -12,13 +12,18 @@ import SwiftUI
 import MijickCalendarView
 import Foundation
 
-extension DV { struct ColoredCircle: DayView {
-    var date: Date
-    var color: Color?
-    var isCurrentMonth: Bool
-    var selectedDate: Binding<Date?>?
-    var selectedRange: Binding<MDateRange?>?
-}}
+extension DV {
+    struct ColoredCircle: DayView {
+        var date: Date
+        var color: Color?
+        var isCurrentMonth: Bool
+        var selectedDate: Binding<Date?>?
+        var selectedRange: Binding<MDateRange?>?
+        var availableDates: [CalendarDate]
+
+        @Environment(\.colorScheme) private var colorScheme
+    }
+}
 
 extension DV.ColoredCircle {
     func createDayLabel() -> AnyView {
@@ -30,73 +35,65 @@ extension DV.ColoredCircle {
         }
         .erased()
     }
+
     func createSelectionView() -> AnyView {
         Circle()
-            .strokeBorder(Color("AccentColor"), lineWidth: 1)
-            .transition(.asymmetric(insertion: .scale(scale: 0.5).combined(with: .opacity), removal: .opacity))
+            .strokeBorder(Color("AccentColor"), lineWidth: 2)
+            .transition(.asymmetric(
+                insertion: .scale(scale: 0.5).combined(with: .opacity),
+                removal: .opacity)
+            )
             .active(if: isSelected())
             .erased()
     }
-    
+
     private func createUnitBorder() -> some View {
         Circle()
             .strokeBorder(unitColor, lineWidth: 2)
             .padding(4)
     }
-}
-private extension DV.ColoredCircle {
-    func createDayLabelBackground() -> some View {
+
+    private func createDayLabelBackground() -> some View {
         Circle()
-            .fill(isSelected() ? Color("AccentColor") : .clear)
+            .fill(isSelected() ? Color("AccentColor") : unitColor)
             .padding(4)
     }
-    func createDayLabelText() -> some View  {
+
+    private func createDayLabelText() -> some View {
         Text(getStringFromDay(format: "d"))
             .font(.regular(17))
             .foregroundColor(getTextColor())
     }
-    
-    // Determine circle fill color based on unit prefix from JSON data
-    private var unitColor: Color {
-        print("🔶 unitColor: checking date \(date)")
-        // Find the matching entry by date
-        guard let entry = DataRepository.shared.calendarEntries.first(where: {
-            Calendar.current.isDate($0.date, inSameDayAs: date)
-        }) else {
-            return .clear
+
+    private func getTextColor() -> Color {
+        if isSelected() {
+            return .white
         }
-        // Extract the two‑letter prefix (e.g. "SF", "TP", etc.)
-        let prefix = String(entry.item.prefix(2))
-        print("  ↪️ prefix: \(prefix)")
-        switch prefix {
-        case "SF": print("  ↪️ prefix: \(prefix)"); return .blue
-        case "TP": print("  ↪️ prefix: \(prefix)"); return .green
-        case "ND": print("  ↪️ prefix: \(prefix)"); return .yellow
-        case "ST": print("  ↪️ prefix: \(prefix)"); return .orange
-        case "TT": print("  ↪️ prefix: \(prefix)"); return .red
-        case "FA": print("  ↪️ prefix: \(prefix)"); return .pink
-        case "PC": print("  ↪️ prefix: \(prefix)"); return .purple
-        case "GC": print("  ↪️ prefix: \(prefix)"); return .mint
-        case "HO": // Holiday
-            print("  ↪️ prefix: \(prefix)")
-            return .gray
-        default:
-            return .clear
-        }
+        return colorScheme == .dark ? .white : .black
     }
 }
 
 private extension DV.ColoredCircle {
-    func getTextColor() -> Color {
-        switch isSelected() {
-        case true: return .white
-        case false: return color == nil ? .onBackgroundPrimary : .white
+    var unitColor: Color {
+        guard let entry = availableDates.first(where: {
+            Calendar.current.isDate($0.date, inSameDayAs: date)
+        }) else {
+            return .gray.opacity(0.2) // fallback for weekends/non-unit days
         }
-    }
-    func getBackgroundColor() -> Color {
-        switch isSelected() {
-        case true: return .onBackgroundPrimary
-        case false: return color ?? .clear
+
+        let prefix = String(entry.label.prefix(2)).uppercased()
+
+        switch prefix {
+        case "SF": return .blue
+        case "TP": return .green
+        case "ND": return .yellow
+        case "ST": return .orange
+        case "TT": return .red
+        case "FA": return .pink
+        case "PC": return .purple
+        case "GC": return .mint
+        case "HO": return .gray
+        default: return .gray.opacity(0.2)
         }
     }
 }

--- a/iOS Dev Calendar/View/CalendarContainerView.swift
+++ b/iOS Dev Calendar/View/CalendarContainerView.swift
@@ -47,11 +47,12 @@ struct CalendarContainerView: View {
             color: CalendarHelpers.color(for: date, available: availableDates),
             isCurrentMonth: isCurrentMonth,
             selectedDate: selectedDate,
-            selectedRange: nil
+            selectedRange: nil,
+            availableDates: availableDates
         )
     }
     
-    // 3️⃣ initializer to wire up the bindings
+    // initializer to wire up the bindings
     init(
         selectedDate: Binding<Date?>,
         availableDates: [CalendarDate],

--- a/iOS Dev Calendar/View/CalendarGridView.swift
+++ b/iOS Dev Calendar/View/CalendarGridView.swift
@@ -24,6 +24,7 @@ struct CalendarGridView: View {
     var body: some View {
         MCalendarView(selectedDate: $selectedDate, selectedRange: nil) { config in
             config
+                .firstWeekday(.sunday)
                 .monthLabel(ML.Uppercased.init)
                 .monthsTopPadding(20)
                 .monthsBottomPadding(10)
@@ -32,30 +33,5 @@ struct CalendarGridView: View {
                 .dayView(buildDayView)
         }
         .scrollDisabled(false)
-    }
-}
-
-// MARK: - Previews
-struct CalendarGridView_Previews: PreviewProvider {
-    @State private static var selectedDate: Date? = nil
-    @State private static var selectedMonth: Date = Date()
-    
-    static var previews: some View {
-        CalendarGridView(
-            selectedDate: $selectedDate,
-            selectedMonth: $selectedMonth,
-            availableDates: DataRepository.shared.calendarEntries.map {
-                CalendarDate(date: $0.date, label: $0.item)
-            },      buildDayView: { date, isSelected, _, _ in
-                DV.ColoredCircle(
-                    date: date,
-                    color: isSelected ? Color("AccentColor") : nil,
-                    isCurrentMonth: true,
-                    selectedDate: nil,
-                    selectedRange: nil
-                )
-            }
-        )
-        .padding()
     }
 }

--- a/iOS Dev Calendar/View/CalendarView.swift
+++ b/iOS Dev Calendar/View/CalendarView.swift
@@ -45,7 +45,8 @@ struct CalendarView: View {
             color: CalendarHelpers.color(for: date, available: availableDates),
             isCurrentMonth: isCurrentMonth,
             selectedDate: selectedDate,
-            selectedRange: nil
+            selectedRange: nil,
+            availableDates: availableDates
         )
     }
 }


### PR DESCRIPTION
## Each date in the calendar will now show if it belongs to a learning unit, weekend, or a holiday. 
* Added color to the background of the dates for each learning unit in the calendar. 
* Now that the JSON loads correctly, the theme for the units works. 
* Also added night and dark mode compatibility for calendar.
* Minor text and formatting fixes
* Addressed the future dates so they have a gray background color if there is no calendar data